### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 ---
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/Tatsh/bincookie/security/code-scanning/2](https://github.com/Tatsh/bincookie/security/code-scanning/2)

To address the issue, the `permissions` key should be added to the workflow file `.github/workflows/qa.yml`. The permissions should be set to the least privilege necessary for the tasks performed by the workflow. Based on the described steps in the workflow, the required permissions are likely `contents: read`. This ensures the workflow can read repository contents without unnecessarily allowing write access.

The `permissions` block can be added at the top level (applying to all jobs) or within the specific `build` job. In this case, adding it to the root of the workflow is preferable for simplicity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
